### PR TITLE
feat: implement manual connection control for camera/microphone

### DIFF
--- a/web/src/components/ChatInterface.tsx
+++ b/web/src/components/ChatInterface.tsx
@@ -17,8 +17,8 @@ interface WebRTCState {
 interface WebRTCActions {
   connect: () => void;
   disconnect: () => void;
-  toggleAudio: (enabled?: boolean) => void;
-  toggleVideo: (enabled?: boolean) => void;
+  toggleAudio: (enabled?: boolean) => Promise<void>
+  toggleVideo: (enabled?: boolean) => Promise<void>
 }
 
 interface ChatInterfaceProps {
@@ -104,7 +104,7 @@ export function ChatInterface({
       <div className="fixed bottom-8 left-1/2 transform -translate-x-1/2">
         <div className="bg-white rounded-[48px] border border-[#EAEAEA] flex items-center gap-8 px-12 py-4" style={{boxShadow: '0 6px 12px 0 rgba(125, 125, 125, 0.15)'}}>
           <button 
-            onClick={() => {
+            onClick={async () => {
               if (!webrtc.isConnected && !webrtc.isConnecting && isMqttConnected) {
                 webrtc.connect();
                 return;
@@ -112,11 +112,11 @@ export function ChatInterface({
 
               if (isRecording) {
                 setIsRecording(false);
-                webrtc.toggleAudio(false);
+                await webrtc.toggleAudio(false);
                 console.log('Stop recording');
               } else {
                 setIsRecording(true);
-                webrtc.toggleAudio(true);
+                await webrtc.toggleAudio(true);
                 console.log('Start recording');
               }
             }}
@@ -135,9 +135,11 @@ export function ChatInterface({
           </button>
           
           <button 
-            onClick={() => {
+            onClick={async () => {
               if (webrtc.isConnected) {
-                webrtc.toggleVideo();
+                await webrtc.toggleVideo();
+              } else {
+                await webrtc.toggleVideo(true);
               }
             }}
             className={`w-12 h-12 rounded-[48px] flex items-center justify-center cursor-pointer transition-all duration-200 ${

--- a/web/src/hooks/useWebRTC.ts
+++ b/web/src/hooks/useWebRTC.ts
@@ -67,16 +67,16 @@ export function useWebRTC({
     setConnectionState('disconnected')
   }, [])
 
-  const toggleAudio = useCallback((enabled?: boolean) => {
+  const toggleAudio = useCallback(async (enabled?: boolean) => {
     if (signalingRef.current) {
-      signalingRef.current.toggleAudio(enabled)
+      await signalingRef.current.toggleAudio(enabled)
       setIsAudioEnabled(enabled !== undefined ? enabled : !isAudioEnabled)
     }
   }, [isAudioEnabled])
 
-  const toggleVideo = useCallback((enabled?: boolean) => {
+  const toggleVideo = useCallback(async (enabled?: boolean) => {
     if (signalingRef.current) {
-      signalingRef.current.toggleVideo(enabled)
+      await signalingRef.current.toggleVideo(enabled)
       setIsVideoEnabled(enabled !== undefined ? enabled : !isVideoEnabled)
     }
   }, [isVideoEnabled])

--- a/web/src/hooks/useWebRTCMqtt.ts
+++ b/web/src/hooks/useWebRTCMqtt.ts
@@ -181,19 +181,45 @@ export function useWebRTCMqtt({
     }
   }, [localStream, remoteStream])
 
-  const toggleAudio = useCallback((enabled?: boolean) => {
-    if (signalingRef.current) {
-      signalingRef.current.toggleAudio(enabled)
-      setIsAudioEnabled(enabled !== undefined ? enabled : !isAudioEnabled)
+  const toggleAudio = useCallback(async (enabled?: boolean) => {
+    const shouldEnable = enabled !== undefined ? enabled : !isAudioEnabled
+    
+    if (shouldEnable) {
+      // If enabling and not connected, reconnect
+      if (!isAudioEnabled && connectionState !== 'connected') {
+        webrtcLogger.info('🎤 Reconnecting for audio...')
+        await connect()
+      } else if (signalingRef.current) {
+        signalingRef.current.toggleAudio(true)
+      }
+      setIsAudioEnabled(true)
+    } else {
+      // If disabling, disconnect the connection
+      webrtcLogger.info('🎤 Disconnecting audio...')
+      disconnect()
+      setIsAudioEnabled(false)
     }
-  }, [isAudioEnabled])
+  }, [isAudioEnabled, connectionState, connect, disconnect])
 
-  const toggleVideo = useCallback((enabled?: boolean) => {
-    if (signalingRef.current) {
-      signalingRef.current.toggleVideo(enabled)
-      setIsVideoEnabled(enabled !== undefined ? enabled : !isVideoEnabled)
+  const toggleVideo = useCallback(async (enabled?: boolean) => {
+    const shouldEnable = enabled !== undefined ? enabled : !isVideoEnabled
+    
+    if (shouldEnable) {
+      // If enabling and not connected, reconnect  
+      if (!isVideoEnabled && connectionState !== 'connected') {
+        webrtcLogger.info('🎥 Reconnecting for video...')
+        await connect()
+      } else if (signalingRef.current) {
+        signalingRef.current.toggleVideo(true)
+      }
+      setIsVideoEnabled(true)
+    } else {
+      // If disabling, disconnect the connection
+      webrtcLogger.info('🎥 Disconnecting video...')
+      disconnect()
+      setIsVideoEnabled(false)
     }
-  }, [isVideoEnabled])
+  }, [isVideoEnabled, connectionState, connect, disconnect])
 
   useEffect(() => {
     if (autoConnect && !hasConnectedRef.current) {

--- a/web/src/services/mqtt-webrtc-signaling.ts
+++ b/web/src/services/mqtt-webrtc-signaling.ts
@@ -333,7 +333,7 @@ export class MqttWebRTCSignaling {
     }
   }
 
-  toggleAudio(enabled?: boolean): void {
+  async toggleAudio(enabled?: boolean): Promise<void> {
     if (!this.localStream) return
     
     const audioTracks = this.localStream.getAudioTracks()

--- a/web/src/services/webrtc-signaling.ts
+++ b/web/src/services/webrtc-signaling.ts
@@ -302,7 +302,7 @@ export class WebRTCSignaling {
   }
 
   // Utility methods
-  toggleAudio(enabled?: boolean): void {
+  async toggleAudio(enabled?: boolean): Promise<void> {
     if (!this.localStream) return
     
     const audioTracks = this.localStream.getAudioTracks()

--- a/web/src/types/webrtc.ts
+++ b/web/src/types/webrtc.ts
@@ -79,8 +79,8 @@ export interface UseWebRTCReturn {
   error: Error | null
   connect: () => Promise<void>
   disconnect: () => void
-  toggleAudio: (enabled?: boolean) => void
-  toggleVideo: (enabled?: boolean) => void
+  toggleAudio: (enabled?: boolean) => Promise<void>
+  toggleVideo: (enabled?: boolean) => Promise<void>
   isAudioEnabled: boolean
   isVideoEnabled: boolean
 }


### PR DESCRIPTION
- Add manual disconnect functionality when toggling audio/video off
- Implement automatic reconnection when toggling back on
- Update toggle functions to be async and fully disconnect/reconnect
- Add comprehensive logging for connection state changes
- Users can now manually control when WebRTC and MQTT connections are active